### PR TITLE
Fix: Build error - 'M_PI' undeclared (Fixes #1)

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -Wpedantic -std=c99 -Iinclude
-LDFLAGS = 
+CFLAGS = -Wall -Wextra -Wpedantic -std=c99 -Iinclude -D_GNU_SOURCE
+LDFLAGS = -lm
 SRCDIR = src
 SOURCES = $(wildcard $(SRCDIR)/*.c)
 OBJECTS = $(SOURCES:.c=.o)


### PR DESCRIPTION
Was getting "M_PI undeclared" errors when building the project. 
Fixed it by adding proper math support to the makefile:

- Added -D_GNU_SOURCE to expose math constants like M_PI
- Added -lm to link against the math library

Now the ASCII art generation works perfectly!

Fixes #1