### PR TITLE
Fix Makefile: move LDFLAGS after objects and remove .x

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,10 +4,10 @@ LDFLAGS = -lm
 SRCDIR = src
 SOURCES = $(wildcard $(SRCDIR)/*.c)
 OBJECTS = $(SOURCES:.c=.o)
-TARGET = ascii-view.x
+TARGET = ascii-view
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $(TARGET)
+	$(CC) $(OBJECTS)  $(LDFLAGS)  -o $(TARGET)
 
 # Release build with optimization
 release: CFLAGS += -O3 -flto -march=native


### PR DESCRIPTION
moved the -lm flag ( LDFLAGS) after the  $(OBJECTS) , and removed the .x  from the make file ("ascii-view.x → ascii-view" )