### PR TITLE
Fix: prevent out-of-bounds access when parsing option values

### DIFF
--- a/src/argparse.c
+++ b/src/argparse.c
@@ -72,14 +72,16 @@ args_t parse_args(int argc, char* argv[]) {
 
     // Get optional parameters
     for (size_t i = 2; i < (size_t) argc; i++) {
-        if (!strcmp(argv[i], "-mw"))
+        if (!strcmp(argv[i], "-mw") && i + 1 < (size_t) argc)
             args.max_width = (size_t) atoi(argv[++i]);
-        else if (!strcmp(argv[i], "-mh"))
+        else if (!strcmp(argv[i], "-mh") && i + 1 < (size_t) argc)
             args.max_height = (size_t) atoi(argv[++i]);
-        else if (!strcmp(argv[i], "-et"))
+        else if (!strcmp(argv[i], "-et") && i + 1 < (size_t) argc)
             args.edge_threshold = atof(argv[++i]);
-        else if (!strcmp(argv[i], "-cr"))
+        else if (!strcmp(argv[i], "-cr") && i + 1 < (size_t) argc)
             args.character_ratio = atof(argv[++i]);
+        else 
+            fprintf(stderr, "Warning: Ignoring invalid or incomplete argument '%s'\n", argv[i]);
     }
 
     return args;


### PR DESCRIPTION
This PR fixes a potential out-of-bounds memory access in the argument parser that occurred when an option flag (`-mw`, `-mh`, `-et`, or `-cr`) was provided without a following value.

Previously, the parser incremented the argument index unconditionally, which could result in reading past `argv[]` bounds and cause undefined behavior or crashes.

(Nice video btw)