### PR TITLE
Added rainbow mode (-r) to ascii-view

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Requirements:
 - `-et <threshold>`: Edge detection threshold, range: 0.0 - 4.0 (default 4.0, disabled)
 - `-cr <ratio>`: Height-to-width ratio for characters (default 2.0)
 - `--retro-colors`: Uses 3-bit colors for pixels.
-- `-r`: Animates ascii image with by hueshifting colors
+- `--rainbow`: Animates ascii image with by hueshifting colors
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A command-line tool that displays images as colorized ASCII art in the terminal.
 ![Cover photo](./cover-photos/coverphoto-1.jpg)
 
 ## Features
+
 - **Multi-format support**: Supports JPEG, PNG, BMP, and other common image formats via [stb_image](https://github.com/nothings/stb)
 - **Color terminal output**: Uses ANSI color codes for colors
 - **Intelligent resizing**: Scales images to fit the terminal's constrained dimensions while maintaining aspect ratio
@@ -14,6 +15,7 @@ A command-line tool that displays images as colorized ASCII art in the terminal.
 ## Building
 
 This project can be built with Make:
+
 ```bash
 # Development version
 make
@@ -23,11 +25,13 @@ make release
 ```
 
 To clean build artifacts:
+
 ```bash
 make clean
 ```
 
 Requirements:
+
 - C99-compatible compiler (GCC, Clang)
 - Make build system
 
@@ -44,6 +48,7 @@ Requirements:
 - `-et <threshold>`: Edge detection threshold, range: 0.0 - 4.0 (default 4.0, disabled)
 - `-cr <ratio>`: Height-to-width ratio for characters (default 2.0)
 - `--retro-colors`: Uses 3-bit colors for pixels.
+- `-r`: Animates ascii image with by hueshifting colors
 
 ### Examples
 
@@ -64,6 +69,7 @@ Requirements:
 The images in the `examples` directory are via [Unsplash](https://unsplash.com)
 
 ### Suggestions for getting good looking results
+
 1. If you make your font size smaller, you can make the pictures larger
 2. The results are limited by your terminal's colour scheme
 3. If you squint your eyes the images look great!

--- a/include/argparse.h
+++ b/include/argparse.h
@@ -10,6 +10,7 @@ typedef struct {
     double character_ratio;
     double edge_threshold;
     int use_retro_colors;
+    int use_rainbow_colors;
 } args_t;
 
 args_t parse_args(int argc, char* argv[]);

--- a/include/print_image.h
+++ b/include/print_image.h
@@ -2,6 +2,14 @@
 #define MY_PRINT_IMAGE
 #include "image.h"
 
+typedef struct {
+    double hue;
+    double saturation;
+    double value;
+} hsv_t;
+
 void print_image(image_t* image, double edge_threshold, int use_retro_colors);
+void print_rainbow_image(image_t* image, double edge_threshold, int use_retro_colors);
+void get_ascii_and_color(char* ascii_dest, hsv_t* hsv_dest, image_t* image, double edge_threshold, int use_retro_colors);
 
 #endif

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -31,6 +31,7 @@ void print_help(char* exec_alias) {
     printf("\t-et <threshold>\t\tEdge detection threshold, range: 0.0 - 4.0 (default: %.1f, disabled)\n", DEFAULT_EDGE_THRESHOLD);
     printf("\t-cr <ratio>\t\tHeight-to-width ratio for characters (default: %.1f)\n", DEFAULT_CHARACTER_RATIO);
     printf("\t--retro-colors\t\tUse 3-bit retro color palette (8 colors) instead of 24-bit truecolor\n");
+    printf("\t-r\t\t\tAnimate ascii art with rainbow by shifting colors\n");
 }
 
 // Get size of terminal in characters. Returns 1 if successful.
@@ -74,6 +75,7 @@ args_t parse_args(int argc, char* argv[]) {
         .character_ratio = DEFAULT_CHARACTER_RATIO,
         .edge_threshold = DEFAULT_EDGE_THRESHOLD,
         .use_retro_colors = 0,
+        .use_rainbow_colors = 0
     };
 
     try_get_terminal_size(&args.max_width, &args.max_height);
@@ -104,6 +106,8 @@ args_t parse_args(int argc, char* argv[]) {
             args.character_ratio = atof(argv[++i]);
         else if (!strcmp(argv[i], "--retro-colors"))
             args.use_retro_colors = 1;
+        else if (!strcmp(argv[i], "-r"))
+            args.use_rainbow_colors = 1;
         else
             fprintf(stderr, "Warning: Ignoring invalid or incomplete argument '%s'\n", argv[i]);
     }

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -106,7 +106,7 @@ args_t parse_args(int argc, char* argv[]) {
             args.character_ratio = atof(argv[++i]);
         else if (!strcmp(argv[i], "--retro-colors"))
             args.use_retro_colors = 1;
-        else if (!strcmp(argv[i], "-r"))
+        else if (!strcmp(argv[i], "--rainbow"))
             args.use_rainbow_colors = 1;
         else
             fprintf(stderr, "Warning: Ignoring invalid or incomplete argument '%s'\n", argv[i]);

--- a/src/argparse.c
+++ b/src/argparse.c
@@ -31,7 +31,7 @@ void print_help(char* exec_alias) {
     printf("\t-et <threshold>\t\tEdge detection threshold, range: 0.0 - 4.0 (default: %.1f, disabled)\n", DEFAULT_EDGE_THRESHOLD);
     printf("\t-cr <ratio>\t\tHeight-to-width ratio for characters (default: %.1f)\n", DEFAULT_CHARACTER_RATIO);
     printf("\t--retro-colors\t\tUse 3-bit retro color palette (8 colors) instead of 24-bit truecolor\n");
-    printf("\t-r\t\t\tAnimate ascii art with rainbow by shifting colors\n");
+    printf("\t-r\t\t\tAnimate ascii art with rainbow by shifting colors (q or Q to quit)\n");
 }
 
 // Get size of terminal in characters. Returns 1 if successful.

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,13 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     
-    print_image(&resized, args.edge_threshold, args.use_retro_colors);
+    //print image or rainbow animation
+    if (!args.use_rainbow_colors) {
+        print_image(&resized, args.edge_threshold, args.use_retro_colors);
+    } else {
+        print_rainbow_image(&resized, args.edge_threshold, args.use_retro_colors);
+    }
+    
     
     free_image(&original);
     free_image(&resized);

--- a/src/print_image.c
+++ b/src/print_image.c
@@ -266,17 +266,30 @@ void print_rainbow_image(image_t* image, double edge_threshold, int use_retro_co
                 printf("\x1b[38;2;%d;%d;%dm%c", r, g, b, ascii_char);
 
                 //now peform a hue rotation on the hsv value and store it for next time
-                hsv.hue += 2.0;
-                if (hsv.hue >= 360.0)
-                    hsv.hue -= 360.0;
+                if(use_retro_colors) {
+                    hsv.hue += 20.0;
+                    if (hsv.hue >= 60.0)
+                        hsv.hue -= 60.0;
+                    
+                    hsvs[y * image->width + x] = hsv;
+                    
+                } else {
+                    hsv.hue += 2.0;
+                    if (hsv.hue >= 360.0)
+                        hsv.hue -= 360.0;
                 
-                hsvs[y * image->width + x] = hsv;
+                    hsvs[y * image->width + x] = hsv;
+                }
 
             }
             printf("\n");
         }
         printf("\x1b[%luA", image->height+1);
-        s_sleep(50);
+        if(use_retro_colors) {
+            s_sleep(1000);
+        } else {
+            s_sleep(50);
+        }
     }
 
     //incase we get here, free memory
@@ -317,7 +330,6 @@ void get_ascii_and_color(char* ascii_dest, hsv_t* hsv_dest, image_t* image, doub
                 hsv_t hsv = rgb_to_hsv(pixel[0], pixel[1], pixel[2]);
                 
                 grayscale = calculate_grayscale_from_hsv(&hsv);
-                hsv.value = 1.0;
 
                 if (use_retro_colors) {
                     // Retro mode: quantize hue to 60° and saturation to 0% or 100%
@@ -325,7 +337,8 @@ void get_ascii_and_color(char* ascii_dest, hsv_t* hsv_dest, image_t* image, doub
                     get_retro_rgb(&hsv, &r, &g, &b);
                     hsv = rgb_to_hsv(r, g, b);
                 }
-
+                
+                hsv.value = 1.0;
                 hsv_dest[index] = hsv;
             }
 


### PR DESCRIPTION
Hello, I added a rainbow feature to the ascii-view project. When -r is enabled, the image will go through a continues color hue shift leading to a cool color-shifting-rainbow effect. It also works with the retro colors enabled. The color shifting continues until a 'q' or 'Q' press is detected. Below is a video of what the color change looks like. If you like this feature and accept the pull request, feel free to tinker with my functions to improve them or change the hue shift rate. Also, I developed this on a apple silicon mac. I did add windows support, but I have not tested it (you may want to test it yourself, or I will eventually test it and redo this pull request. Whatever works best).

[demo_video.zip](https://github.com/user-attachments/files/23063801/demo_video.zip)

Take it easy,
-Alexander

